### PR TITLE
refactor CDP setup so id is set up earlier

### DIFF
--- a/src/eth/Cdp.js
+++ b/src/eth/Cdp.js
@@ -94,7 +94,7 @@ const passthroughMethods = [
 Object.assign(
   Cdp.prototype,
   passthroughMethods.reduce((acc, name) => {
-    acc[name] = async function(...args) {
+    acc[name] = function(...args) {
       return this._cdpService[name](this.id, ...args);
     };
     return acc;

--- a/src/eth/Cdp.js
+++ b/src/eth/Cdp.js
@@ -9,11 +9,13 @@ export default class Cdp {
     this._transactionManager = this._smartContractService.get(
       'transactionManager'
     );
-    if (cdpId === null) {
-      this._cdpIdPromise = this._newCdpPromise();
+
+    if (!cdpId) {
+      this._create();
     } else {
-      this._cdpIdPromise = Promise.resolve(cdpId);
+      this.id = cdpId;
     }
+
     this._emitterInstance = this._cdpService.get('event').buildEmitter();
     this.on = this._emitterInstance.on;
     this._emitterInstance.registerPollEvents({
@@ -27,39 +29,35 @@ export default class Cdp {
     });
   }
 
-  _captureCdpIdPromise(tubContract) {
+  _create() {
+    const tubContract = this._smartContractService.getContractByName(
+      contracts.SAI_TUB
+    );
+
     const currentAccount = this._smartContractService
       .get('web3')
       .currentAccount();
 
-    return new Promise(resolve => {
+    const getId = new Promise(resolve => {
       tubContract.onlognewcup = function(address, cdpIdBytes32) {
         if (currentAccount.toLowerCase() == address.toLowerCase()) {
-          const cdpId = ethersUtils.bigNumberify(cdpIdBytes32).toNumber();
           this.removeListener();
-          resolve(cdpId);
+          resolve(ethersUtils.bigNumberify(cdpIdBytes32).toNumber());
         }
       };
     });
-  }
 
-  _newCdpPromise() {
-    const tubContract = this._smartContractService.getContractByName(
-      contracts.SAI_TUB,
-      { hybrid: false }
+    this._transactionObject = this._transactionManager.createHybridTx(
+      (async () => {
+        const [id, openResult] = await Promise.all([getId, tubContract.open()]);
+        this.id = id;
+        return openResult;
+      })(),
+      {
+        businessObject: this,
+        metadata: { contract: 'SAI_TUB', method: 'open' }
+      }
     );
-    const captureCdpIdPromise = this._captureCdpIdPromise(tubContract);
-
-    // FIXME push this back down into SmartContractService
-    this._transactionObject = this._transactionManager.formatHybridTx(
-      tubContract,
-      'open',
-      [],
-      'SAI_TUB',
-      this
-    );
-
-    return captureCdpIdPromise.then(result => result);
   }
 
   transactionObject() {
@@ -67,7 +65,7 @@ export default class Cdp {
   }
 
   getId() {
-    return this._cdpIdPromise;
+    return Promise.resolve(this.id);
   }
 }
 
@@ -97,7 +95,7 @@ Object.assign(
   Cdp.prototype,
   passthroughMethods.reduce((acc, name) => {
     acc[name] = async function(...args) {
-      return this._cdpService[name](await this.getId(), ...args);
+      return this._cdpService[name](this.id, ...args);
     };
     return acc;
   }, {})

--- a/src/eth/TransactionObject.js
+++ b/src/eth/TransactionObject.js
@@ -34,10 +34,6 @@ export default class TransactionObject extends TransactionLifeCycle {
     return this._fees;
   }
 
-  hash() {
-    return this._hash;
-  }
-
   async mine() {
     if (!this._dataPromise) this._dataPromise = this._getTransactionData();
     await this._dataPromise;
@@ -50,7 +46,7 @@ export default class TransactionObject extends TransactionLifeCycle {
     const newBlockNumber = this._receipt.blockNumber + count;
     await this._web3Service.waitForBlockNumber(newBlockNumber);
     const newReceipt = await this._ethersProvider.getTransactionReceipt(
-      this._hash
+      this.hash
     );
     if (newReceipt.blockHash !== this._receipt.blockHash) {
       throw new Error('transaction block hash changed');
@@ -63,13 +59,13 @@ export default class TransactionObject extends TransactionLifeCycle {
     try {
       let gasPrice = null;
       let tx = await this._transaction;
-      this._hash = tx.hash;
+      this.hash = tx.hash;
       this.setPending(); // set state to pending
 
       // when you're on a local testnet, a single call to getTransaction should
       // be enough. but on a remote net, it may take multiple calls.
       for (let i = 0; i < 10; i++) {
-        tx = await this._ethersProvider.getTransaction(this._hash);
+        tx = await this._ethersProvider.getTransaction(this.hash);
         if (tx) break;
         await promiseWait(1500);
       }
@@ -83,10 +79,10 @@ export default class TransactionObject extends TransactionLifeCycle {
       // it to be mined.
       if (!tx.blockHash) {
         const startTime = new Date();
-        log(`waitForTransaction ${this._hash}`);
-        tx = await this._ethersProvider.waitForTransaction(this._hash);
+        log(`waitForTransaction ${this.hash}`);
+        tx = await this._ethersProvider.waitForTransaction(this.hash);
         const elapsed = (new Date() - startTime) / 1000;
-        log(`waitForTransaction ${this._hash} done in ${elapsed}s`);
+        log(`waitForTransaction ${this.hash} done in ${elapsed}s`);
       }
 
       gasPrice = tx.gasPrice;
@@ -118,7 +114,7 @@ export default class TransactionObject extends TransactionLifeCycle {
 
   _waitForReceipt(retries = 5) {
     const result = Promise.resolve(
-      this._ethersProvider.getTransactionReceipt(this._hash)
+      this._ethersProvider.getTransactionReceipt(this.hash)
     );
 
     if (retries < 1) return result;


### PR DESCRIPTION
this removes the need for `await this.getId()` in the passthrough methods