### PR TITLE
Transactions should go to error state if they revert

### DIFF
--- a/src/eth/TransactionObject.js
+++ b/src/eth/TransactionObject.js
@@ -109,7 +109,7 @@ export default class TransactionObject extends TransactionLifeCycle {
         //transaction reverted
         const revertMsg = `transaction with hash ${this.hash} reverted`;
         log(revertMsg);
-        this.setError(revertMsg);
+        throw new Error(revertMsg);
       }
     } catch (err) {
       await this._nonceService.setCounts();

--- a/src/eth/TransactionObject.js
+++ b/src/eth/TransactionObject.js
@@ -89,7 +89,6 @@ export default class TransactionObject extends TransactionLifeCycle {
       gasPrice = tx.gasPrice;
       this._timeStampMined = new Date();
       const receipt = (this._receipt = await this._waitForReceipt());
-
       if (typeof this._logsParser === 'function') {
         this._logsParser(receipt.logs);
       }

--- a/test/eth/TransactionObject.spec.js
+++ b/test/eth/TransactionObject.spec.js
@@ -22,7 +22,7 @@ function createTestTransaction(srv = service) {
 
 function createRevertingTransaction(srv = service) {
   const mkr = srv.getToken(MKR);
-  return mkr.transfer('0xe30d7f884b87681bd8f5bf1e818eb029a90ad9d2', '2000000');
+  return mkr.transfer(TestAccountProvider.nextAddress(), '2000000');
 }
 
 test('event listeners work as promises', async () => {

--- a/test/eth/TransactionObject.spec.js
+++ b/test/eth/TransactionObject.spec.js
@@ -134,32 +134,13 @@ test('reverted transaction using callback', async () => {
   tx.onMined(() => {
     mined = true;
   });
-  tx.onError(error => {
-    expect(tx.state()).toBe(TransactionState.error);
+  try {
+    await tx.mine();
+  } catch (err) {
+    expect(tx.state()).toEqual(TransactionState.error);
     expect(mined).toBe(false);
-    expect(error).toMatch('reverted');
-  });
-
-  await tx.mine();
-});
-
-test('reverted transaction using promise', async () => {
-  expect.assertions(4);
-  let mined = false;
-  const tx = createRevertingTransaction(service);
-  tx.onPending(() => {
-    expect(tx.state()).toBe(TransactionState.pending);
-  });
-  tx.onMined(() => {
-    mined = true;
-  });
-  tx.onError().then(error => {
-    expect(tx.state()).toBe(TransactionState.error);
-    expect(mined).toBe(false);
-    expect(error).toMatch('reverted');
-  });
-
-  await tx.mine();
+    expect(err.message).toMatch('reverted');
+  }
 });
 
 test('error event listener works', async () => {

--- a/test/helpers/transactionConfirmation.js
+++ b/test/helpers/transactionConfirmation.js
@@ -1,9 +1,33 @@
-import { WETH } from '../../src/eth/Currency';
+import { ETH, WETH, MKR } from '../../src/eth/Currency';
 import TestAccountProvider from './TestAccountProvider';
 
 export function createTestTransaction(tokenService) {
   const wethToken = tokenService.getToken(WETH);
   return wethToken.approveUnlimited(TestAccountProvider.nextAddress());
+}
+
+export function createRevertingTransaction(tokenService) {
+  const mkr = tokenService.getToken(MKR);
+  return mkr.transfer(TestAccountProvider.nextAddress(), '2000000');
+}
+
+export function createBelowBaseFeeTransaction(tokenService) {
+  const mkr = tokenService.getToken(MKR);
+  return mkr._contract.approve(TestAccountProvider.nextAddress(), -1, {
+    gasLimit: 4000
+  });
+}
+
+export function createOutOfGasTransaction(tokenService) {
+  const mkr = tokenService.getToken(MKR);
+  return mkr._contract.approve(TestAccountProvider.nextAddress(), -1, {
+    gasLimit: 40000
+  });
+}
+
+export function createOutOfEthTransaction(tokenService) {
+  const eth = tokenService.getToken(ETH);
+  return eth.transfer(TestAccountProvider.nextAddress(), 20000);
 }
 
 export function mineBlocks(tokenService, count = 5) {


### PR DESCRIPTION
If the `status` field in the transaction receipt is 0, it means that the transaction reverted.

I still need to merge this with the integration test work, but it looks like that isn't passing travis so am holding off on that for now.