### PR TITLE
New yarn command to watch & rebuild files

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
     "babel-preset-stage-2": "^6.24.1",
+    "chokidar": "^2.0.4",
     "copyfiles": "^2.0.0",
     "eslint": "^5.3.0",
     "eslint-loader": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build:frontend": "./scripts/build-frontend.sh",
     "build:backend": "./scripts/build-backend.sh",
     "build:backend:watch": "sane ./scripts/build-backend.sh src --wait=10",
+    "build:backend:src:watch": "./scripts/watch-backend-src.sh",
     "coverage": "./scripts/run-testchain.sh --ci jest --runInBand --coverage --config ./test/config/jestDefaultConfig.json",
     "lint": "eslint web src test",
     "precommit": "lint-staged",

--- a/scripts/watch-backend-src.sh
+++ b/scripts/watch-backend-src.sh
@@ -1,24 +1,42 @@
 #!/usr/bin/env bash
 
-# install inotify-tools - https://github.com/rvoicilas/inotify-tools/wiki
 
-FILE="dist/src/Maker.js"
+cd $(npm root) && cd ..  
+
+CHECK_FILE="dist/src/Maker.js"
 BUILD_BACKEND="./scripts/build-backend.sh"
 
-if [ ! -f $FILE ]; then
+if [ ! -f $CHECK_FILE ]; then
   echo "no dist/ present, building..."
   (exec "$BUILD_BACKEND")  
 fi
 
-DIST="dist/"
-CURPATH=`pwd`
+CWD=`pwd`
+DIST="$CWD/dist/src/"
 
-inotifywait -mr --timefmt '%d/%m/%y %H:%M' --format '%T %w %f' \
--e close_write src/ | while read date time dir file; do
+cd "src" 
 
-  FILECHANGE=${dir}${file}
-  # convert absolute path to relative
-  FILECHANGEREL=`echo "$FILECHANGE" | sed 's_'$CURPATH'/__'`
-  babel $FILECHANGE -o $DIST$FILECHANGEREL
-  echo "At ${time} on ${date}, file $FILECHANGE was compiled to $DIST$FILECHANGEREL"
+WATCHERS_READY=false
+
+node ../scripts/watch-src.js | \
+  while IFS= read -r line 
+  do
+    if [ "$WATCHERS_READY" = true ]; then
+      ACTION=`echo $line | awk '{print $1;}'`
+      FILE=`echo $line | awk '{print $2;}'`
+      
+      if [ "$ACTION" = "deleted" ]; then
+        rm "$DIST$FILE"
+      else
+        babel $FILE -o $DIST$FILE
+      fi
+
+      echo "$ACTION $DIST$FILE"
+    fi
+
+    if [ "$line" = "loaded files, watching" ]; then
+      WATCHERS_READY=true
+      echo $line
+    fi
 done
+

--- a/scripts/watch-backend-src.sh
+++ b/scripts/watch-backend-src.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# install inotify-tools - https://github.com/rvoicilas/inotify-tools/wiki
+
+FILE="dist/src/Maker.js"
+BUILD_BACKEND="./scripts/build-backend.sh"
+
+if [ ! -f $FILE ]; then
+  echo "no dist/ present, building..."
+  (exec "$BUILD_BACKEND")  
+fi
+
+DIST="dist/"
+CURPATH=`pwd`
+
+inotifywait -mr --timefmt '%d/%m/%y %H:%M' --format '%T %w %f' \
+-e close_write src/ | while read date time dir file; do
+
+  FILECHANGE=${dir}${file}
+  # convert absolute path to relative
+  FILECHANGEREL=`echo "$FILECHANGE" | sed 's_'$CURPATH'/__'`
+  babel $FILECHANGE -o $DIST$FILECHANGEREL
+  echo "At ${time} on ${date}, file $FILECHANGE was compiled to $DIST$FILECHANGEREL"
+done

--- a/scripts/watch-src.js
+++ b/scripts/watch-src.js
@@ -1,0 +1,13 @@
+var chokidar = require('chokidar');
+
+var log = console.log.bind(console);
+var watcher = chokidar.watch('.', {
+  ignored: /[\/\\]\./, persistent: true
+});
+
+watcher
+  .on('ready', function() { log(`loaded files, watching`); })
+  .on('add', function(path) { log(`added ${path}`); })
+  .on('change', function(path) { log(`changed ${path}`); })
+  .on('unlink', function(path) { log(`deleted ${path}`); });
+


### PR DESCRIPTION
If using the dist folder as a local library, the previous watch command, `yarn build:backend:watch`, was quite inefficient and required the whole dist folder to recompile. 

`yarn build:backend:src:watch` will watch for saves to any files under `src/` and compile them to `dist/src`.

Dependency requirement for [inotify-tools](https://github.com/rvoicilas/inotify-tools/wiki)