### PR TITLE
Add events to AccountsService

### DIFF
--- a/src/eth/AccountsService.js
+++ b/src/eth/AccountsService.js
@@ -13,7 +13,7 @@ const sanitizeAccount = pick(['name', 'type', 'address']);
 
 export default class AccountsService extends PublicService {
   constructor(name = 'accounts') {
-    super(name, ['log']);
+    super(name, ['log', 'event']);
     this._accounts = {};
     this._accountFactories = {
       privateKey: privateKeyAccountFactory,
@@ -83,6 +83,9 @@ export default class AccountsService extends PublicService {
     if (!this._currentAccount || name === 'default') {
       this.useAccount(name);
     }
+
+    this.get('event').emit('accounts/ADD', { account });
+
     return account;
   }
 
@@ -113,6 +116,8 @@ export default class AccountsService extends PublicService {
     // add the provider at index 0 so that it takes precedence over RpcSource
     this._engine.addProvider(this.currentWallet(), 0);
     this._engine.start();
+
+    this.get('event').emit('accounts/CHANGE', { account });
   }
 
   _getAccountWithAddress(addr) {

--- a/src/eth/AccountsService.js
+++ b/src/eth/AccountsService.js
@@ -84,7 +84,7 @@ export default class AccountsService extends PublicService {
       this.useAccount(name);
     }
 
-    this.get('event').emit('accounts/ADD', { account });
+    this.get('event').emit('accounts/ADD', { account: sanitizeAccount(account) });
 
     return account;
   }
@@ -117,7 +117,7 @@ export default class AccountsService extends PublicService {
     this._engine.addProvider(this.currentWallet(), 0);
     this._engine.start();
 
-    this.get('event').emit('accounts/CHANGE', { account });
+    this.get('event').emit('accounts/CHANGE', { account: this.currentAccount() });
   }
 
   _getAccountWithAddress(addr) {


### PR DESCRIPTION
What do we think about `accounts/CHANGE` and `accounts/ADD` as event names?
Also, do we want tests around these? given it's only a side effect and we don't seem to be testing events that rigorously.
And we should do a round of updates to the documentation, there are other events such as `allowance/APPROVE` not listed there
