### PR TITLE
mcd-plugin: allow address overrides

### DIFF
--- a/lib/dai-plugin-mcd/src/index.js
+++ b/lib/dai-plugin-mcd/src/index.js
@@ -1,4 +1,4 @@
-import { mapValues } from 'lodash';
+import { mapValues, isEmpty } from 'lodash';
 import { createCurrency, createCurrencyRatio } from '@makerdao/currency';
 import addresses from '../contracts/addresses/testnet.json';
 import abiMap from '../contracts/abiMap.json';
@@ -9,7 +9,7 @@ import SystemDataService from './SystemDataService';
 import { ServiceRoles } from './constants';
 const { CDP_MANAGER, CDP_TYPE, SYSTEM_DATA, AUCTION } = ServiceRoles;
 
-const mcdContracts = mapValues(abiMap, (abiName, name) => ({
+let mcdContracts = mapValues(abiMap, (abiName, name) => ({
   // TODO add kovan and mainnet addresses
   address: addresses[name],
   abi: require(`../contracts/abis/${abiName}.json`)
@@ -27,27 +27,30 @@ export const USD_REP = createCurrencyRatio(USD, REP);
 export const USD_DGX = createCurrencyRatio(USD, DGX);
 
 export default {
-  addConfig: (_, { cdpTypes }) => ({
-    smartContract: {
-      addContracts: mcdContracts
-    },
-    token: {
-      erc20: [
-        { currency: REP, ...mcdContracts.REP },
-        { currency: DGX, ...mcdContracts.DGX },
-        { currency: MDAI, ...mcdContracts.MCD_DAI },
-        { currency: WETH, ...mcdContracts.WETH }
-      ]
-    },
-    additionalServices: [
-      CDP_MANAGER,
-      CDP_TYPE,
-      AUCTION,
-      SYSTEM_DATA
-    ],
-    [CDP_TYPE]: [CdpTypeService, { cdpTypes }],
-    [CDP_MANAGER]: CdpManager,
-    [AUCTION]: AuctionService,
-    [SYSTEM_DATA]: SystemDataService
-  })
+  addConfig: (_, { cdpTypes, addressOverrides = {} } = {}) => {
+    if (!isEmpty(addressOverrides))
+      mcdContracts = mapValues(mcdContracts, (contractDetails, name) => ({
+        ...contractDetails,
+        address: addressOverrides[name] || contractDetails.address
+      }));
+
+    return {
+      smartContract: {
+        addContracts: mcdContracts
+      },
+      token: {
+        erc20: [
+          { currency: REP, ...mcdContracts.REP },
+          { currency: DGX, ...mcdContracts.DGX },
+          { currency: MDAI, ...mcdContracts.MCD_DAI },
+          { currency: WETH, ...mcdContracts.WETH }
+        ]
+      },
+      additionalServices: [CDP_MANAGER, CDP_TYPE, AUCTION, SYSTEM_DATA],
+      [CDP_TYPE]: [CdpTypeService, { cdpTypes }],
+      [CDP_MANAGER]: CdpManager,
+      [AUCTION]: AuctionService,
+      [SYSTEM_DATA]: SystemDataService
+    };
+  }
 };

--- a/lib/dai-plugin-mcd/test/helpers.js
+++ b/lib/dai-plugin-mcd/test/helpers.js
@@ -6,7 +6,7 @@ import { ServiceRoles } from '../src/constants';
 import { stringToBytes } from '../src/utils';
 import ethAbi from 'web3-eth-abi';
 
-export async function mcdMaker(settings) {
+export async function mcdMaker({ addressOverrides = {}, ...settings } = {}) {
   const maker = await Maker.create('test', {
     plugins: [
       [
@@ -20,7 +20,8 @@ export async function mcdMaker(settings) {
             // TODO not ready for this one yet -- need the ability to
             // deploy contracts from within JS
             // { currency: REP, name: 'REP-ALT' }
-          ]
+          ],
+          addressOverrides
         }
       ]
     ],

--- a/lib/dai-plugin-mcd/test/index.spec.js
+++ b/lib/dai-plugin-mcd/test/index.spec.js
@@ -15,6 +15,20 @@ test('contract address mapping', async () => {
   expect(address).toEqual(addresses.PIP_DGX);
 });
 
+test('mcd contract addresses can be overridden', async () => {
+  const RANDOM_ADDRESS = '0x520cca6e73540fa2d483232d7545ee8fadd8a23d';
+  expect(RANDOM_ADDRESS).not.toEqual(addresses.PIP_DGX);
+  const addressOverrides = {
+    PIP_DGX: RANDOM_ADDRESS
+  };
+
+  const customMakerInstance = await mcdMaker({ addressOverrides });
+  const makerPipDgxAddress = customMakerInstance
+    .service('smartContract')
+    .getContractAddressByName('PIP_DGX');
+  expect(makerPipDgxAddress).toEqual(RANDOM_ADDRESS);
+});
+
 test('REP token basic functionality', async () => {
   const rep = maker.getToken('REP');
   expect(rep.address()).toEqual(addresses.REP);


### PR DESCRIPTION
Makes it easier for us to experiment with different dcs deployments in the mcd portal 

