### PR TITLE
infuraApiKey -> infuraProjectId

### DIFF
--- a/lib/dai-plugin-mcd/test/Auction.spec.js
+++ b/lib/dai-plugin-mcd/test/Auction.spec.js
@@ -3,7 +3,7 @@ import { ServiceRoles } from '../src/constants';
 
 const scenarios = [['ETH-A'], ['MDAI'], ['MKR']];
 
-describe.each(scenarios)('%s', (ilk) => {
+describe.each(scenarios)('%s', ilk => {
   let auction;
 
   beforeAll(async () => {

--- a/lib/dai-plugin-mcd/test/CdpTypeService.spec.js
+++ b/lib/dai-plugin-mcd/test/CdpTypeService.spec.js
@@ -16,11 +16,7 @@ let maker, service;
 
 // these CDP types should be available to the Maker instance because
 // of the configuration passed into it (see test/helpers.js)
-const scenarios = [
-  ['ETH-A', ETH],
-  ['ETH-B', ETH],
-  ['COL1-A', COL1]
-];
+const scenarios = [['ETH-A', ETH], ['ETH-B', ETH], ['COL1-A', COL1]];
 
 beforeAll(async () => {
   maker = await mcdMaker();
@@ -35,7 +31,7 @@ describe.each(scenarios)('%s', (ilk, GEM) => {
     cdpType = service.getCdpType(GEM, ilk);
     ratio = createCurrencyRatio(USD, GEM);
 
-      // await setupPriceFeed(maker, ilk, GEM);
+    // await setupPriceFeed(maker, ilk, GEM);
     await setLiquidationRatio(maker, ilk, ratio(1));
 
     await setupCollateral(maker, ilk, { price: 10, debtCeiling: 111 });

--- a/src/eth/AccountsService.js
+++ b/src/eth/AccountsService.js
@@ -84,7 +84,9 @@ export default class AccountsService extends PublicService {
       this.useAccount(name);
     }
     if (this.hasAccount()) {
-      this.get('event').emit('accounts/ADD', { account: sanitizeAccount(account) });
+      this.get('event').emit('accounts/ADD', {
+        account: sanitizeAccount(account)
+      });
     }
 
     return account;
@@ -118,7 +120,9 @@ export default class AccountsService extends PublicService {
     this._engine.addProvider(this.currentWallet(), 0);
     this._engine.start();
     if (this.hasAccount()) {
-      this.get('event').emit('accounts/CHANGE', { account: this.currentAccount() });
+      this.get('event').emit('accounts/CHANGE', {
+        account: this.currentAccount()
+      });
     }
   }
 

--- a/src/eth/accounts/setup.js
+++ b/src/eth/accounts/setup.js
@@ -72,22 +72,28 @@ export async function getBrowserProvider() {
   }
 }
 
-function getInfuraUrl(protocol = 'https', network, infuraApiKey) {
+function getInfuraUrl(protocol = 'https', network, infuraProjectId) {
+  if (!infuraProjectId) {
+    throw new Error(
+      'Cannot use infura without a project ID'
+    );
+  }
   let url = `${protocol}://${network}.infura.io`;
   url += protocol === 'wss' ? '/ws' : '';
-  url += infuraApiKey ? `/${infuraApiKey}` : '';
+  url += '/v3';
+  url += `/${infuraProjectId}`;
   return url;
 }
 
 function getRpcUrl(providerSettings) {
-  const { network, protocol, infuraApiKey, type, url } = providerSettings;
+  const { network, protocol, infuraProjectId, type, url } = providerSettings;
   switch (type) {
     case ProviderType.HTTP:
       return url;
     case ProviderType.WEBSOCKET:
       return url;
     case ProviderType.INFURA:
-      return getInfuraUrl(protocol, network, infuraApiKey);
+      return getInfuraUrl(protocol, network, infuraProjectId);
     default:
       throw new Error('Invalid web3 provider type: ' + type);
   }

--- a/src/eth/accounts/setup.js
+++ b/src/eth/accounts/setup.js
@@ -74,14 +74,11 @@ export async function getBrowserProvider() {
 
 function getInfuraUrl(protocol = 'https', network, infuraProjectId) {
   if (!infuraProjectId) {
-    throw new Error(
-      'Cannot use infura without a project ID'
-    );
+    throw new Error('Cannot use infura without a project ID');
   }
   let url = `${protocol}://${network}.infura.io`;
   url += protocol === 'wss' ? '/ws' : '';
-  url += '/v3';
-  url += `/${infuraProjectId}`;
+  url += `/v3/${infuraProjectId}`;
   return url;
 }
 

--- a/test/eth/Web3Service.spec.js
+++ b/test/eth/Web3Service.spec.js
@@ -81,7 +81,7 @@ function buildInfuraService(network, privateKey = null) {
       provider: {
         type: ProviderType.INFURA,
         network,
-        infuraProjectId: infuraProjectId
+        infuraProjectId
       },
       transactionSettings: {
         gasLimit: 4000000

--- a/test/eth/Web3Service.spec.js
+++ b/test/eth/Web3Service.spec.js
@@ -2,6 +2,7 @@ import TestAccountProvider from '../helpers/TestAccountProvider';
 import ProviderType from '../../src/eth/web3/ProviderType';
 import { captureConsole } from '../../src/utils';
 import { buildTestService as buildTestServiceCore } from '../helpers/serviceBuilders';
+import { infuraProjectId } from '../helpers/serviceBuilders';
 
 function buildDisconnectingService(disconnectAfter = 25) {
   const service = buildTestService(null, disconnectAfter + 25);
@@ -80,7 +81,7 @@ function buildInfuraService(network, privateKey = null) {
       provider: {
         type: ProviderType.INFURA,
         network,
-        infuraApiKey: process.env.INFURA_API_KEY
+        infuraProjectId: infuraProjectId
       },
       transactionSettings: {
         gasLimit: 4000000

--- a/test/helpers/serviceBuilders.js
+++ b/test/helpers/serviceBuilders.js
@@ -10,7 +10,7 @@ export const kovanProviderConfig = {
     provider: {
       type: ProviderType.INFURA,
       network: 'kovan',
-      infuraProjectId: infuraProjectId
+      infuraProjectId
     }
   }
 };

--- a/test/helpers/serviceBuilders.js
+++ b/test/helpers/serviceBuilders.js
@@ -2,13 +2,15 @@ import DefaultServiceProvider from '../../src/config/DefaultServiceProvider';
 import ProviderType from '../../src/eth/web3/ProviderType';
 import { has, merge } from 'lodash';
 
+export const infuraProjectId = 'c3f0f26a4c1742e0949d8eedfc47be67'; //dai.js project id
+
 export const kovanProviderConfig = {
   web3: {
     privateKey: process.env.KOVAN_PRIVATE_KEY,
     provider: {
       type: ProviderType.INFURA,
       network: 'kovan',
-      infuraApiKey: process.env.INFURA_API_KEY
+      infuraProjectId: infuraProjectId
     }
   }
 };

--- a/test/infura.spec.js
+++ b/test/infura.spec.js
@@ -2,7 +2,7 @@ import Maker from '../src/index';
 
 test('use Kovan via Infura without project id throws', async () => {
   try {
-  	const maker = await Maker.create('kovan', { log: false });
+    const maker = await Maker.create('kovan', { log: false });
     await maker.authenticate();
   } catch (err) {
     expect(err).toBeInstanceOf(Error);

--- a/test/infura.spec.js
+++ b/test/infura.spec.js
@@ -1,6 +1,10 @@
 import Maker from '../src/index';
 
-test('use Kovan via Infura without API key', async () => {
-  const maker = await Maker.create('kovan', { log: false });
-  await maker.authenticate();
+test('use Kovan via Infura without project id throws', async () => {
+  try {
+  	const maker = await Maker.create('kovan', { log: false });
+    await maker.authenticate();
+  } catch (err) {
+    expect(err).toBeInstanceOf(Error);
+  }
 });

--- a/test/integration/dai.spec.js
+++ b/test/integration/dai.spec.js
@@ -4,6 +4,7 @@ import { WETH } from '../../src/eth/Currency';
 import debug from 'debug';
 import createDaiAndPlaceLimitOrder from '../helpers/oasisHelpers';
 import { uniqueId } from '../../src/utils';
+import { infuraProjectId } from '../helpers/serviceBuilders';
 
 const log = debug('dai:testing:integration');
 let maker, cdp, exchange, address, tokenService, txMgr;
@@ -71,6 +72,9 @@ beforeAll(async () => {
             transactionSettings: {
               gasPrice: 15000000000,
               gasLimit: 4000000
+            },
+            provider: {
+              infuraProjectId: infuraProjectId
             }
           }
         };

--- a/test/integration/dai.spec.js
+++ b/test/integration/dai.spec.js
@@ -74,7 +74,7 @@ beforeAll(async () => {
               gasLimit: 4000000
             },
             provider: {
-              infuraProjectId: infuraProjectId
+              infuraProjectId
             }
           }
         };


### PR DESCRIPTION
Infura is supposed to stop supporting requests not using the new Dashboard Project Ids today, per: https://blog.infura.io/infura-dashboard-update-9f02d0643eb3

This PR uses the new endpoints in the kovan and mainnet presets, which are used in the integration tests.  An error is thrown if these presets are used without providing an `infuraProjectId`.