### PR TITLE
Feature/cdp manager assert

### DIFF
--- a/lib/dai-plugin-mcd/README.md
+++ b/lib/dai-plugin-mcd/README.md
@@ -54,3 +54,9 @@ functions convert those values to return a decimal representation of the yearly
 rates (e.g. `0.015` and `0.01`).
 
 Run the tests from the top-level dai.js directory.
+
+### Local Development
+Due to the way that Babel7 handles transpilation it is not possible to use `yarn link` when locally developing this plugin, and importing it. We recommend using [yalc](https://github.com/whitecolor/yalc) instead. We've also found that a watcher tool called [sane](https://github.com/amasad/sane) is helpful.
+
+Steps to Run:
+1. In this directory run ```sane "yalc publish && cd [INSERT THE DIRECTORY OF THE PROJECT THAT IS IMPORTING THIS PLUGIN] && yalc link @makerdao/dai-plugin-mcd" src --wait=3 ```

--- a/lib/dai-plugin-mcd/package.json
+++ b/lib/dai-plugin-mcd/package.json
@@ -14,5 +14,8 @@
     "@makerdao/currency": "^0.9.0",
     "@makerdao/services-core": "^0.9.5",
     "bignumber.js": "^8.1.1"
+  },
+  "devDependencies": {
+    "sane": "^4.1.0"
   }
 }

--- a/lib/dai-plugin-mcd/src/CdpManager.js
+++ b/lib/dai-plugin-mcd/src/CdpManager.js
@@ -110,6 +110,7 @@ export default class CdpManager extends LocalService {
   }
 
   getIdBytes(id, prefix = true) {
+    assert(typeof id === 'number', 'ID must be a number');
     return (prefix ? '0x' : '') + padStart(id.toString(16), 24, '0');
   }
 

--- a/lib/dai-plugin-mcd/src/ManagedCdp.js
+++ b/lib/dai-plugin-mcd/src/ManagedCdp.js
@@ -7,6 +7,7 @@ import { MDAI } from './index';
 
 export default class ManagedCdp {
   constructor(id, ilk, cdpManager) {
+    assert(typeof id === 'number', 'ID must be a number');
     this.id = id;
 
     assert(ilk && typeof ilk === 'string', 'Must specify ilk');


### PR DESCRIPTION
Implemented 2 separate assert statements for the cdp id to be an integer, one in CDPManager and one in ManagedCDP. This is a fix to a bug where a string was being passed and not converted correctly.