### PR TITLE
read price from osm feed struct (do not merge)

### DIFF
--- a/lib/dai-plugin-mcd/src/CdpType.js
+++ b/lib/dai-plugin-mcd/src/CdpType.js
@@ -62,9 +62,14 @@ export default class CdpType {
       return ratio.ray((await this.ilkInfo()).spot);
     }
 
-    const val = await this._web3Service.getStorageAt(this._pipAddress, 2);
+    const feedStruct = await this._web3Service.getStorageAt(
+      this._pipAddress,
+      3
+    );
+    const val = '0x' + feedStruct.substr(34);
+
     //TODO: verify correct number of decimals for val
-    return ratio.wei(new BigNumber(val.toString()));
+    return ratio.wei(new BigNumber(val));
   }
 
   async getLiquidationPenalty() {


### PR DESCRIPTION
I think `PIP_*` refers refers to the `osm` in the latest deployment, so I tweaked `getPrice` to read [the current price value](https://github.com/makerdao/osm/blob/db1fceece712dd05608131f26a49c4f8896d0fb2/src/osm.sol#L45). I can fix the test here, but i'm not totally clear on when we're using `median` rather than `osm`, and which of them pip should refer to, so I wanted to check with you first :)