### PR TITLE
Detect browser account switch via autoSwitch flag

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,7 @@
         ],
         "complexity": [
             "error",
-            12
+            13
         ]
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -32,7 +32,7 @@
         ],
         "complexity": [
             "error",
-            13
+            12
         ]
     }
 }

--- a/src/eth/AccountsService.js
+++ b/src/eth/AccountsService.js
@@ -20,7 +20,6 @@ export default class AccountsService extends PublicService {
       provider: providerAccountFactory,
       browser: browserProviderAccountFactory
     };
-    this._autoSwitchCheckHandle = null;
   }
 
   async initialize(settings = {}) {
@@ -59,7 +58,7 @@ export default class AccountsService extends PublicService {
       options = name;
       name = null;
     }
-    const { type, ...otherSettings } = options;
+    const { type, autoSwitch, ...otherSettings } = options;
     invariant(this._engine, 'engine must be set up before adding an account');
     if (name && this._accounts[name]) {
       throw new Error('An account with this name already exists.');
@@ -81,8 +80,8 @@ export default class AccountsService extends PublicService {
     }
 
     if (!name) name = accountData.address;
-    const account = { name, type, ...accountData };
-    if (otherSettings.autoSwitch) account.autoSwitch = otherSettings.autoSwitch;
+    const account = { name, type, autoSwitch: autoSwitch || false, ...accountData };
+
     this._accounts[name] = account;
     if (!this._currentAccount || name === 'default') {
       this.useAccount(name);

--- a/src/eth/AccountsService.js
+++ b/src/eth/AccountsService.js
@@ -89,6 +89,25 @@ export default class AccountsService extends PublicService {
       });
     }
 
+    // Detect account change and automatically switch active account if
+    // autoSwitch flag set (Useful if using a browser wallet like MetaMask)
+    // See: https://github.com/MetaMask/faq/blob/master/DEVELOPERS.md#ear-listening-for-selected-account-changes
+    if (otherSettings.autoSwitch && type === AccountType.BROWSER) {
+      const accountCheckHandle = setInterval(async () => {
+        const activeBrowserAddress = window.web3.eth.defaultAccount.toLowerCase();
+        if (activeBrowserAddress !== accountData.address) {
+          clearInterval(accountCheckHandle);
+          if (!this._getAccountWithAddress(activeBrowserAddress)) {
+            await this.addAccount({
+              type: AccountType.BROWSER,
+              autoSwitch: true
+            });
+          }
+          this.useAccount(window.web3.eth.defaultAccount.toLowerCase());
+        }
+      }, 500);
+    }
+
     return account;
   }
 

--- a/src/eth/accounts/factories.js
+++ b/src/eth/accounts/factories.js
@@ -28,7 +28,10 @@ async function getAccountAddress(subprovider) {
     subprovider.handleRequest(
       { method: 'eth_accounts', params: [], id: 1 },
       null,
-      (err, val) => (err ? reject(err) : resolve(val[0]))
+      (err, val) =>
+        err
+          ? reject(err)
+          : resolve(typeof val[0] === 'string' ? val[0].toLowerCase() : val[0])
     )
   );
 }


### PR DESCRIPTION
Opt-in `autoSwitch` flag for `addAccount` – useful for detecting when a user changes the active account in MetaMask and have the SDK automatically switch to it.