### PR TITLE
cmooney-2019071101: fix proxy null error

### DIFF
--- a/packages/dai/src/eth/EthereumCdpService.js
+++ b/packages/dai/src/eth/EthereumCdpService.js
@@ -92,7 +92,7 @@ export default class EthereumCdpService extends PrivateService {
     }
 
     const proxy = await this.get('proxy').currentProxy();
-    if (owner === proxy.toLowerCase()) {
+    if (proxy && owner === proxy.toLowerCase()) {
       return new ProxyCdp(this, proxy, id);
     }
 

--- a/packages/dai/test/eth/EthereumCdpService.spec.js
+++ b/packages/dai/test/eth/EthereumCdpService.spec.js
@@ -55,9 +55,6 @@ describe('find cdp', () => {
     const cdps = buildTestEthereumCdpService({
       accounts: {
         default: { type: 'privateKey', ...TestAccountProvider.nextAccount() }
-      },
-      proxy: {
-        currentProxy: async () => { return null; }
       }
     });
     await cdps.manager().authenticate();

--- a/packages/dai/test/eth/EthereumCdpService.spec.js
+++ b/packages/dai/test/eth/EthereumCdpService.spec.js
@@ -55,28 +55,13 @@ describe('find cdp', () => {
     const cdps = buildTestEthereumCdpService({
       accounts: {
         default: { type: 'privateKey', ...TestAccountProvider.nextAccount() }
+      },
+      proxy: {
+        currentProxy: async () => { return null; }
       }
     });
     await cdps.manager().authenticate();
-    const saved = { get: cdps.get };
-    // stub out get to return null on currentProxy
-    cdps.get = type => {
-      let ret;
-      switch (type) {
-        case 'proxy':
-          ret = {
-            currentProxy: async () => {
-              return null;
-            }
-          };
-          break;
-        default:
-          ret = saved.get.bind(cdps)(type);
-      }
-      return ret;
-    };
     const sameCdp = await cdps.getCdp(cdp.id);
-    cdps.get = saved.get;
     expect(sameCdp.id).toEqual(cdp.id);
     expect(sameCdp.dsProxyAddress).not.toBeDefined();
   });

--- a/packages/dai/test/eth/EthereumCdpService.spec.js
+++ b/packages/dai/test/eth/EthereumCdpService.spec.js
@@ -2,6 +2,7 @@ import { buildTestEthereumCdpService } from '../helpers/serviceBuilders';
 import { USD_DAI } from '../../src/eth/Currency';
 import Cdp from '../../src/eth/Cdp';
 import { mineBlocks } from '../helpers/transactionConfirmation';
+import TestAccountProvider from '../helpers/TestAccountProvider';
 
 let cdpService;
 
@@ -46,6 +47,36 @@ describe('find cdp', () => {
 
   test('returns a normal cdp', async () => {
     const sameCdp = await cdpService.getCdp(cdp.id);
+    expect(sameCdp.id).toEqual(cdp.id);
+    expect(sameCdp.dsProxyAddress).not.toBeDefined();
+  });
+
+  test('regression: handle null proxy correctly', async () => {
+    const cdps = buildTestEthereumCdpService({
+      accounts: {
+        default: { type: 'privateKey', ...TestAccountProvider.nextAccount() }
+      }
+    });
+    await cdps.manager().authenticate();
+    const saved = { get: cdps.get };
+    // stub out get to return null on currentProxy
+    cdps.get = type => {
+      let ret;
+      switch (type) {
+        case 'proxy':
+          ret = {
+            currentProxy: async () => {
+              return null;
+            }
+          };
+          break;
+        default:
+          ret = saved.get.bind(cdps)(type);
+      }
+      return ret;
+    };
+    const sameCdp = await cdps.getCdp(cdp.id);
+    cdps.get = saved.get;
     expect(sameCdp.id).toEqual(cdp.id);
     expect(sameCdp.dsProxyAddress).not.toBeDefined();
   });


### PR DESCRIPTION
This fixes the null dereference error below.

```
TypeError: Cannot read property 'toLowerCase' of null
    at EthereumCdpService._callee$ (/makerdao/makerdao-scripts/node_modules/@makerdao/dai/src/eth/EthereumCdpService.js:144:37)
    at tryCatch (/makerdao/makerdao-scripts/node_modules/regenerator-runtime/runtime.js:45:40)
    at Generator.invoke [as _invoke] (/makerdao/makerdao-scripts/node_modules/regenerator-runtime/runtime.js:271:22)
    at Generator.prototype.(anonymous function) [as next] (/makerdao/makerdao-scripts/node_modules/regenerator-runtime/runtime.js:97:21)
    at asyncGeneratorStep (/makerdao/makerdao-scripts/node_modules/@babel/runtime/helpers/asyncToGenerator.js:3:24)
    at _next (/makerdao/makerdao-scripts/node_modules/@babel/runtime/helpers/asyncToGenerator.js:25:9)
    at processTicksAndRejections (internal/process/next_tick.js:81:5)
```

Since the code is transpiled, this is my best guess at the location of the fix.  When I make this same change in the transpiled code it works correctly.  This should resolve the bug.

To reproduce in the wild you can save this code to the file `reproduce.mjs`:
```js
#!/usr/bin/env node

import Maker from '@makerdao/dai';

// pub key: 0xDA0a37FAb65EB2E3767C4f050166dDAe88d13fDF

async function getDaiOwed() {
  const maker = await Maker.create("http", {
    privateKey: '61a88425ec63e518893e9eb25ae36cc9c7511b4dca04a0e115d0ff882a460df3',
    url: 'https://cloudflare-eth.com/'
  });

  await maker.authenticate();

  try {
    const fail = await maker.getCdp(18170);
  } catch (err) {
    console.log(err);
    process.exit(1);
  }
}

(async () => {
  await getDaiOwed();
  process.exit();
})();
```

and run the following commands:
```
mkdir reproduce
cd reproduce
npm init
npm install @makerdao/dai
node --experimental-modules ./reproduce.mjs
```