### PR TITLE
Prepublish script

### DIFF
--- a/packages/dai-plugin-mcd/package.json
+++ b/packages/dai-plugin-mcd/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@makerdao/dai-plugin-mcd",
   "description": "Plugin to add Multi-Collateral Dai support to dai.js",
-  "version": "0.8.10",
+  "version": "0.2.10-1",
   "license": "MIT",
   "main": "dist",
   "scripts": {
     "build": "yarn prepublishOnly",
-    "preversion": "",
     "prepublishOnly": "./scripts/prepublish.sh",
     "testchain": "../../scripts/run-testchain.sh",
     "coverage": "yarn test --coverage",

--- a/packages/dai-plugin-mcd/package.json
+++ b/packages/dai-plugin-mcd/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@makerdao/dai-plugin-mcd",
   "description": "Plugin to add Multi-Collateral Dai support to dai.js",
-  "version": "0.2.10-1",
+  "version": "0.8.10",
   "license": "MIT",
   "main": "dist",
   "scripts": {
     "build": "yarn prepublishOnly",
+    "preversion": "",
     "prepublishOnly": "./scripts/prepublish.sh",
     "testchain": "../../scripts/run-testchain.sh",
     "coverage": "yarn test --coverage",

--- a/packages/dai-plugin-mcd/package.json
+++ b/packages/dai-plugin-mcd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@makerdao/dai-plugin-mcd",
   "description": "Plugin to add Multi-Collateral Dai support to dai.js",
-  "version": "0.2.11",
+  "version": "0.2.10-1",
   "license": "MIT",
   "main": "dist",
   "scripts": {

--- a/packages/dai-plugin-mcd/package.json
+++ b/packages/dai-plugin-mcd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@makerdao/dai-plugin-mcd",
   "description": "Plugin to add Multi-Collateral Dai support to dai.js",
-  "version": "0.2.10-1",
+  "version": "0.2.11",
   "license": "MIT",
   "main": "dist",
   "scripts": {

--- a/packages/dai-plugin-mcd/scripts/prepublish.sh
+++ b/packages/dai-plugin-mcd/scripts/prepublish.sh
@@ -5,7 +5,7 @@ if [ $(basename $(pwd)) != "dai-plugin-mcd" ]; then
   exit
 fi
 
-yarn config set version-tag-prefix 'dai-plugin-mcd-v'
+yarn config set version-tag-prefix "dai-plugin-mcd-v"
 yarn config set version-git-message "dai-plugin-mcd-v%s"
 yarn version
 

--- a/packages/dai-plugin-mcd/scripts/prepublish.sh
+++ b/packages/dai-plugin-mcd/scripts/prepublish.sh
@@ -9,16 +9,6 @@ yarn config set version-tag-prefix "dai-plugin-mcd-v"
 yarn config set version-git-message "dai-plugin-mcd-v%s"
 yarn version
 
-PACKAGE_VERSION=$(cat package.json \
-  | grep version \
-  | head -1 \
-  | awk -F: '{ print $2 }' \
-  | sed 's/[",]//g')
-
-git push origin dev --no-verify
-git push origin "dai-plugin-mcd-v${PACKAGE_VERSION:1}"
-
-CWD=`dirname $0`
 rm -rf dist/*
 cd ../..
 ./node_modules/.bin/babel --no-babelrc -d packages/dai-plugin-mcd/dist packages/dai-plugin-mcd/src

--- a/packages/dai-plugin-mcd/scripts/prepublish.sh
+++ b/packages/dai-plugin-mcd/scripts/prepublish.sh
@@ -5,7 +5,9 @@ if [ $(basename $(pwd)) != "dai-plugin-mcd" ]; then
   exit
 fi
 
-lerna version --tag-version-prefix="dai-plugin-mcd-v" --conventional-commits --create-release github
+yarn config set version-tag-prefix 'dai-plugin-mcd-v'
+yarn version
+
 CWD=`dirname $0`
 rm -rf dist/*
 cd ../..

--- a/packages/dai-plugin-mcd/scripts/prepublish.sh
+++ b/packages/dai-plugin-mcd/scripts/prepublish.sh
@@ -4,6 +4,8 @@ if [ $(basename $(pwd)) != "dai-plugin-mcd" ]; then
   echo "This script must be run from the dai-plugin-mcd directory."
   exit
 fi
+
+lerna version --conventional-commits --create-release github
 CWD=`dirname $0`
 rm -rf dist/*
 cd ../..

--- a/packages/dai-plugin-mcd/scripts/prepublish.sh
+++ b/packages/dai-plugin-mcd/scripts/prepublish.sh
@@ -5,7 +5,7 @@ if [ $(basename $(pwd)) != "dai-plugin-mcd" ]; then
   exit
 fi
 
-lerna version --conventional-commits --create-release github
+lerna version --tag-version-prefix="dai-plugin-mcd-v" --conventional-commits --create-release github
 CWD=`dirname $0`
 rm -rf dist/*
 cd ../..

--- a/packages/dai-plugin-migrations/scripts/prepublish.sh
+++ b/packages/dai-plugin-migrations/scripts/prepublish.sh
@@ -5,7 +5,7 @@ if [ $(basename $(pwd)) != "dai-plugin-migrations" ]; then
   exit
 fi
 
-yarn config set version-tag-prefix 'dai-plugin-migrations-v'
+yarn config set version-tag-prefix "dai-plugin-migrations-v"
 yarn config set version-git-message "dai-plugin-migrations-v%s"
 yarn version
 

--- a/packages/dai-plugin-migrations/scripts/prepublish.sh
+++ b/packages/dai-plugin-migrations/scripts/prepublish.sh
@@ -9,16 +9,6 @@ yarn config set version-tag-prefix "dai-plugin-migrations-v"
 yarn config set version-git-message "dai-plugin-migrations-v%s"
 yarn version
 
-PACKAGE_VERSION=$(cat package.json \
-  | grep version \
-  | head -1 \
-  | awk -F: '{ print $2 }' \
-  | sed 's/[",]//g')
-
-git push origin dev --no-verify
-git push origin "dai-plugin-migrations-v${PACKAGE_VERSION:1}"
-
-CWD=`dirname $0`
 rm -rf dist/*
 cd ../..
 ./node_modules/.bin/babel --no-babelrc -d packages/dai-plugin-migrations/dist packages/dai-plugin-migrations/src

--- a/packages/dai-plugin-migrations/scripts/prepublish.sh
+++ b/packages/dai-plugin-migrations/scripts/prepublish.sh
@@ -5,7 +5,7 @@ if [ $(basename $(pwd)) != "dai-plugin-migrations" ]; then
   exit
 fi
 
-lerna version --conventional-commits --create-release github
+lerna version --tag-version-prefix="dai-plugin-migrations-v" --conventional-commits --create-release github
 CWD=`dirname $0`
 rm -rf dist/*
 cd ../..

--- a/packages/dai-plugin-migrations/scripts/prepublish.sh
+++ b/packages/dai-plugin-migrations/scripts/prepublish.sh
@@ -5,7 +5,9 @@ if [ $(basename $(pwd)) != "dai-plugin-migrations" ]; then
   exit
 fi
 
-lerna version --tag-version-prefix="dai-plugin-migrations-v" --conventional-commits --create-release github
+yarn config set version-tag-prefix 'dai-plugin-migrations-v'
+yarn version
+
 CWD=`dirname $0`
 rm -rf dist/*
 cd ../..

--- a/packages/dai-plugin-migrations/scripts/prepublish.sh
+++ b/packages/dai-plugin-migrations/scripts/prepublish.sh
@@ -4,6 +4,8 @@ if [ $(basename $(pwd)) != "dai-plugin-migrations" ]; then
   echo "This script must be run from the dai-plugin-migrations directory."
   exit
 fi
+
+lerna version --conventional-commits --create-release github
 CWD=`dirname $0`
 rm -rf dist/*
 cd ../..

--- a/packages/dai/package.json
+++ b/packages/dai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerdao/dai",
-  "version": "0.17.1",
+  "version": "0.17.8",
   "contributors": [
     "Wouter Kampmann <wouter@makerdao.com>",
     "Sean Brennan <sean@makerdao.com>",

--- a/packages/dai/package.json
+++ b/packages/dai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@makerdao/dai",
-  "version": "0.17.8",
+  "version": "0.17.1",
   "contributors": [
     "Wouter Kampmann <wouter@makerdao.com>",
     "Sean Brennan <sean@makerdao.com>",

--- a/packages/dai/package.json
+++ b/packages/dai/package.json
@@ -42,6 +42,7 @@
     "build:backend": "./scripts/build-backend.sh",
     "build:backend:watch": "sane ./scripts/build-backend.sh src --wait=10",
     "build:backend:src:watch": "./scripts/watch-backend-src.sh",
+    "prepublishOnly": "./scripts/prepublish.sh",
     "test:watch": "yarn test --watch",
     "test:mainnet": "export NETWORK='mainnet' && jest --runInBand --config ./test/config/jestIntegrationConfig.json",
     "test:kovan": "export NETWORK='kovan' && jest --runInBand --config ./test/config/jestIntegrationConfig.json",

--- a/packages/dai/scripts/prepublish.sh
+++ b/packages/dai/scripts/prepublish.sh
@@ -5,7 +5,9 @@ if [ $(basename $(pwd)) != "dai" ]; then
   exit
 fi
 
-lerna version --tag-version-prefix="dai-v" --conventional-commits --create-release github
+yarn config set version-tag-prefix 'dai-v'
+yarn version
+
 CWD=`dirname $0`
 rm -rf dist/*
 ./build-backend.sh

--- a/packages/dai/scripts/prepublish.sh
+++ b/packages/dai/scripts/prepublish.sh
@@ -8,6 +8,5 @@ fi
 lerna version --tag-version-prefix="dai-v" --conventional-commits --create-release github
 CWD=`dirname $0`
 rm -rf dist/*
-cd ../..
 ./build-backend.sh
 cd - >/dev/null

--- a/packages/dai/scripts/prepublish.sh
+++ b/packages/dai/scripts/prepublish.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+if [ $(basename $(pwd)) != "dai" ]; then
+  echo "This script must be run from the dai directory."
+  exit
+fi
+
+lerna version --tag-version-prefix="dai-v" --conventional-commits --create-release github
+CWD=`dirname $0`
+rm -rf dist/*
+cd ../..
+./build-backend.sh
+cd - >/dev/null

--- a/packages/dai/scripts/prepublish.sh
+++ b/packages/dai/scripts/prepublish.sh
@@ -5,7 +5,7 @@ if [ $(basename $(pwd)) != "dai" ]; then
   exit
 fi
 
-yarn config set version-tag-prefix 'dai-v'
+yarn config set version-tag-prefix "dai-v"
 yarn config set version-git-message "dai-v%s"
 yarn version
 

--- a/packages/dai/scripts/prepublish.sh
+++ b/packages/dai/scripts/prepublish.sh
@@ -9,13 +9,4 @@ yarn config set version-tag-prefix "dai-v"
 yarn config set version-git-message "dai-v%s"
 yarn version
 
-rm -rf dist/*
-babel contracts --out-dir ./dist/contracts
-babel contracts/addresses --out-dir ./dist/contracts/addresses
-babel src --out-dir ./dist/src
-
-copyfiles \
-  contracts/abis/* \
-  src/config/presets/* \
-  contracts/addresses/* \
-  dist
+./scripts/build-backend.sh

--- a/packages/dai/scripts/prepublish.sh
+++ b/packages/dai/scripts/prepublish.sh
@@ -9,16 +9,6 @@ yarn config set version-tag-prefix "dai-v"
 yarn config set version-git-message "dai-v%s"
 yarn version
 
-PACKAGE_VERSION=$(cat package.json \
-  | grep version \
-  | head -1 \
-  | awk -F: '{ print $2 }' \
-  | sed 's/[",]//g')
-
-git push origin dev --no-verify
-git push origin "dai-v${PACKAGE_VERSION:1}"
-
-CWD=`dirname $0`
 rm -rf dist/*
 babel contracts --out-dir ./dist/contracts
 babel contracts/addresses --out-dir ./dist/contracts/addresses
@@ -29,5 +19,3 @@ copyfiles \
   src/config/presets/* \
   contracts/addresses/* \
   dist
-
-cd dist/


### PR DESCRIPTION
This is a small change, but worth a PR (since it will affect the publication process).

* Prepublish script in the `dai` package means it can now be published from the root directory of the package, like we do in `dai-plugin-mcd`
* In any package, publishing will now prompt you to enter a new version number
* It will then automatically update the version, commit the change, and create a tag prefixed with the package name