### PR TITLE
Change node requirement to >=10.16

### DIFF
--- a/packages/dai/package.json
+++ b/packages/dai/package.json
@@ -70,6 +70,6 @@
     "web3-provider-engine": "makerdao/provider-engine#kovan-fix-dist"
   },
   "engines": {
-    "node": ">=10.16"
+    "node": ">=10.16 <12"
   }
 }

--- a/packages/dai/package.json
+++ b/packages/dai/package.json
@@ -70,6 +70,6 @@
     "web3-provider-engine": "makerdao/provider-engine#kovan-fix-dist"
   },
   "engines": {
-    "node": "11.10"
+    "node": ">=10.16"
   }
 }


### PR DESCRIPTION
Set node requirement to >=10.16 (Dubnium LTS) in dai package, so it can be used with node versions other than 11.10.

Would fix https://github.com/makerdao/dai.js/issues/151