### PR TITLE
Collateralization ratio units

### DIFF
--- a/packages/dai-plugin-mcd/src/math.js
+++ b/packages/dai-plugin-mcd/src/math.js
@@ -62,7 +62,11 @@ export function debtValue(art, rate) {
 }
 
 export function collateralizationRatio(collateralValue, debtValue) {
-  return debtValue.eq(0) ? Infinity : collateralValue.div(debtValue);
+  if (debtValue.eq(0)) {
+    const ratio = createCurrencyRatio(USD, MDAI);
+    return ratio(Infinity);
+  }
+  return collateralValue.div(debtValue);
 }
 
 export function liquidationPrice(

--- a/packages/dai-plugin-mcd/src/math.js
+++ b/packages/dai-plugin-mcd/src/math.js
@@ -62,7 +62,7 @@ export function debtValue(art, rate) {
 }
 
 export function collateralizationRatio(collateralValue, debtValue) {
-  return debtValue.eq(0) ? Infinity : collateralValue.div(debtValue).toNumber();
+  return debtValue.eq(0) ? Infinity : collateralValue.div(debtValue);
 }
 
 export function liquidationPrice(

--- a/packages/dai-plugin-mcd/src/math.js
+++ b/packages/dai-plugin-mcd/src/math.js
@@ -62,7 +62,7 @@ export function debtValue(art, rate) {
 }
 
 export function collateralizationRatio(collateralValue, debtValue) {
-  return debtValue.eq(0) ? Infinity : collateralValue.div(debtValue);
+  return debtValue.eq(0) ? Infinity : collateralValue.div(debtValue).toNumber();
 }
 
 export function liquidationPrice(

--- a/packages/dai-plugin-mcd/test/CdpType.spec.js
+++ b/packages/dai-plugin-mcd/test/CdpType.spec.js
@@ -117,5 +117,5 @@ test('get system-wide collateral value', async () => {
 
 test('get system-wide collateralization ratio', async () => {
   const totalCollateralizationRatioAllCdpTypes = await service.totalCollateralizationRatioAllCdpTypes;
-  expect(totalCollateralizationRatioAllCdpTypes).toBeCloseTo(5);
+  expect(totalCollateralizationRatioAllCdpTypes.toNumber()).toBeCloseTo(5);
 });

--- a/packages/dai-plugin-mcd/test/CdpType.spec.js
+++ b/packages/dai-plugin-mcd/test/CdpType.spec.js
@@ -117,5 +117,5 @@ test('get system-wide collateral value', async () => {
 
 test('get system-wide collateralization ratio', async () => {
   const totalCollateralizationRatioAllCdpTypes = await service.totalCollateralizationRatioAllCdpTypes;
-  expect(totalCollateralizationRatioAllCdpTypes.toNumber()).toBeCloseTo(5);
+  expect(totalCollateralizationRatioAllCdpTypes).toBeCloseTo(5);
 });

--- a/packages/dai-plugin-mcd/test/ManagedCdp.spec.js
+++ b/packages/dai-plugin-mcd/test/ManagedCdp.spec.js
@@ -101,7 +101,7 @@ async function expectValues(
     );
   }
   if (ratio !== undefined) {
-    expect(cdp.collateralizationRatio).toBe(ratio);
+    expect(cdp.collateralizationRatio.toNumber()).toBe(ratio);
   }
   if (isSafe !== undefined) {
     expect(cdp.isSafe).toBe(isSafe);

--- a/packages/dai-plugin-mcd/test/ManagedCdp.spec.js
+++ b/packages/dai-plugin-mcd/test/ManagedCdp.spec.js
@@ -101,7 +101,7 @@ async function expectValues(
     );
   }
   if (ratio !== undefined) {
-    expect(cdp.collateralizationRatio.toNumber()).toBe(ratio);
+    expect(cdp.collateralizationRatio).toBe(ratio);
   }
   if (isSafe !== undefined) {
     expect(cdp.isSafe).toBe(isSafe);

--- a/packages/dai-plugin-mcd/test/ManagedCdp.spec.js
+++ b/packages/dai-plugin-mcd/test/ManagedCdp.spec.js
@@ -47,8 +47,9 @@ test('liquidationPrice and collateralizationRatio are infinite with 0 collateral
   const cdp = await maker.service(CDP_MANAGER).open('REP-A');
   await cdp.prefetch();
   const ratio = createCurrencyRatio(USD, REP);
+  const ratio2 = createCurrencyRatio(USD, MDAI);
   expect(cdp.liquidationPrice).toEqual(ratio(Infinity));
-  expect(cdp.collateralizationRatio).toEqual(Infinity);
+  expect(cdp.collateralizationRatio).toEqual(ratio2(Infinity));
 });
 
 async function expectValuesAfterReset(cdp, values) {

--- a/packages/dai/test/eth/tokens/EtherToken.spec.js
+++ b/packages/dai/test/eth/tokens/EtherToken.spec.js
@@ -90,7 +90,7 @@ test('ether transfer should move transferValue from sender to receiver', done =>
       // sender also pays tx fee, so their balance is lower
       expect(newSenderBalance.plus(0.1).toNumber()).toBeCloseTo(
         senderBalance.toNumber(),
-        3
+        2
       );
       done();
     });
@@ -128,7 +128,7 @@ test('ether transferFrom should move transferValue from sender to receiver', don
       // sender also pays tx fee, so their balance is lower
       expect(newSenderBalance.plus(0.1).toNumber()).toBeCloseTo(
         senderBalance.toNumber(),
-        3
+        2
       );
       done();
     });


### PR DESCRIPTION
Change math.collateralizationRatio to return a number instead of a USD/DAI currency ratio, since technically there is no unit for the collateralization ratio, and so that the return type is the same if Infinity is returned