### PR TITLE
ensure QueryApi.getCdpIdsForOwner converts the address arg to a check…

### DIFF
--- a/packages/dai/src/QueryApi.js
+++ b/packages/dai/src/QueryApi.js
@@ -1,5 +1,6 @@
-import fetch from 'isomorphic-fetch';
 import assert from 'assert';
+import ethUtil from 'ethereumjs-util';
+import fetch from 'isomorphic-fetch';
 
 const MAINNET_SERVER_URL = 'https://sai-mainnet.makerfoundation.com/v1';
 const KOVAN_SERVER_URL = 'https://sai-kovan.makerfoundation.com/v1';
@@ -22,27 +23,6 @@ export async function getQueryResponse(serverUrl, query, variables) {
   return data;
 }
 
-// sample code from EIP-55 "Mixed-case checksum address encoding":
-// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
-function toChecksumAddress(address) {
-  address = address.toLowerCase().replace('0x', '');
-  const createKeccakHash = require('keccak');
-  var hash = createKeccakHash('keccak256')
-    .update(address)
-    .digest('hex');
-  var ret = '0x';
-
-  for (var i = 0; i < address.length; i++) {
-    if (parseInt(hash[i], 16) >= 8) {
-      ret += address[i].toUpperCase();
-    } else {
-      ret += address[i];
-    }
-  }
-
-  return ret;
-}
-
 export default class QueryApi {
   constructor(network) {
     switch (network) {
@@ -60,7 +40,7 @@ export default class QueryApi {
   }
 
   async getCdpIdsForOwner(rawAddress) {
-    const address = toChecksumAddress(rawAddress);
+    const address = ethUtil.toChecksumAddress(rawAddress);
     const query = `query ($lad: String) {
       allCups(condition: { lad: $lad }) {
         nodes {

--- a/packages/dai/src/QueryApi.js
+++ b/packages/dai/src/QueryApi.js
@@ -22,6 +22,27 @@ export async function getQueryResponse(serverUrl, query, variables) {
   return data;
 }
 
+// sample code from EIP-55 "Mixed-case checksum address encoding":
+// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md
+function toChecksumAddress(address) {
+  address = address.toLowerCase().replace('0x', '');
+  const createKeccakHash = require('keccak');
+  var hash = createKeccakHash('keccak256')
+    .update(address)
+    .digest('hex');
+  var ret = '0x';
+
+  for (var i = 0; i < address.length; i++) {
+    if (parseInt(hash[i], 16) >= 8) {
+      ret += address[i].toUpperCase();
+    } else {
+      ret += address[i];
+    }
+  }
+
+  return ret;
+}
+
 export default class QueryApi {
   constructor(network) {
     switch (network) {
@@ -38,7 +59,8 @@ export default class QueryApi {
     }
   }
 
-  async getCdpIdsForOwner(address) {
+  async getCdpIdsForOwner(rawAddress) {
+    const address = toChecksumAddress(rawAddress);
     const query = `query ($lad: String) {
       allCups(condition: { lad: $lad }) {
         nodes {

--- a/packages/dai/test/QueryApi.spec.js
+++ b/packages/dai/test/QueryApi.spec.js
@@ -3,7 +3,7 @@ import QueryApi from '../src/QueryApi';
 test('getCdpIdsForOwner on kovan', async () => {
   const q = new QueryApi('kovan');
   const ids = await q.getCdpIdsForOwner(
-    '0x90d01F84F8Db06d9aF09054Fe06fb69C1f8ee9E9'
+    '0x90d01f84f8db06d9af09054fe06fb69c1f8ee9e9'
   );
   expect(ids).toEqual([4756]);
 });


### PR DESCRIPTION
…sumAddress

Summary:

the dai.js library code seems to convert most addresses to lowercase. This is
presumably done to make it canonical, and perhaps easier to compare. Not entirely
sure.

However, when querying the server via graphql, the server expects a checksumAddress
with the appropriate characters uppercase and lowercase. See EIP-55 for details.
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md

So, this change does that.

Ideally, we'd refactor the code so that it always uses this checksum-encoding
for the address, but that seems like a larger change than i am comfortable
making at the moment.

Test Plan:

this code works for me when i call it in my own repo using the @makerdao/dai
library. Um, i basically copy-pasta'd the entire QueryApi code into my repo,
and modified it as shown here.

Prior to having this code, any call to `getCdpIdsForOwner` would return an empty array.