### PR TITLE
Add skip version update flag to prepublish script

### DIFF
--- a/packages/dai-plugin-mcd/scripts/prepublish.sh
+++ b/packages/dai-plugin-mcd/scripts/prepublish.sh
@@ -5,8 +5,10 @@ if [ $(basename $(pwd)) != "dai-plugin-mcd" ]; then
   exit
 fi
 
-yarn config set version-tag-prefix "dai-plugin-mcd-v"
-yarn config set version-git-message "dai-plugin-mcd-v%s"
-yarn version
+if [ ! SKIP_VERSION_UPDATE ]; then
+  yarn config set version-tag-prefix "dai-plugin-mcd-v"
+  yarn config set version-git-message "dai-plugin-mcd-v%s"
+  yarn version
+fi
 
 ./scripts/build.sh

--- a/packages/dai-plugin-migrations/scripts/prepublish.sh
+++ b/packages/dai-plugin-migrations/scripts/prepublish.sh
@@ -5,8 +5,10 @@ if [ $(basename $(pwd)) != "dai-plugin-migrations" ]; then
   exit
 fi
 
-yarn config set version-tag-prefix "dai-plugin-migrations-v"
-yarn config set version-git-message "dai-plugin-migrations-v%s"
-yarn version
+if [ ! SKIP_VERSION_UPDATE ]; then
+  yarn config set version-tag-prefix "dai-plugin-migrations-v"
+  yarn config set version-git-message "dai-plugin-migrations-v%s"
+  yarn version
+fi
 
 ./scripts/build.sh

--- a/packages/dai/scripts/prepublish.sh
+++ b/packages/dai/scripts/prepublish.sh
@@ -5,8 +5,10 @@ if [ $(basename $(pwd)) != "dai" ]; then
   exit
 fi
 
-yarn config set version-tag-prefix "dai-v"
-yarn config set version-git-message "dai-v%s"
-yarn version
+if [ ! SKIP_VERSION_UPDATE ]; then
+  yarn config set version-tag-prefix "dai-v"
+  yarn config set version-git-message "dai-v%s"
+  yarn version
+fi
 
 ./scripts/build-backend.sh


### PR DESCRIPTION
Add `SKIP_VERSION_UPDATE` flag so that `yalc publish` can be used automatically (e.g. via `sane`) without prompting for a new version number.

e.g. `SKIP_VERSION_UPDATE=true yalc publish`