### PR TITLE
ESM History

### DIFF
--- a/packages/dai-plugin-governance/src/EsmService.js
+++ b/packages/dai-plugin-governance/src/EsmService.js
@@ -4,7 +4,7 @@ import { getCurrency } from './utils/helpers';
 
 export default class EsmService extends PrivateService {
   constructor(name = 'esm') {
-    super(name, ['smartContract', 'web3', 'token', 'allowance']);
+    super(name, ['smartContract', 'web3', 'token', 'allowance', 'govQueryApi']);
   }
 
   async thresholdAmount() {
@@ -79,6 +79,27 @@ export default class EsmService extends PrivateService {
       }
     }
     return this._esmContract().fire();
+  }
+
+  async getStakingHistory() {
+    const stakes = await this.get('govQueryApi').getEsmJoins();
+    const parsedStakes = stakes.map(e => {
+      const transactionHash = e.txHash;
+      const senderAddress = e.txFrom;
+      const amount = MKR(e.joinAmount);
+      const time = new Date(e.blockTimestamp);
+      return {
+        transactionHash,
+        senderAddress,
+        amount,
+        time
+      };
+    });
+    const sortedParsedStakes = parsedStakes.sort((a, b) => {
+      //sort by date descending
+      return b.time - a.time;
+    });
+    return sortedParsedStakes;
   }
 
   _esmContract() {

--- a/packages/dai-plugin-governance/src/GovQueryApiService.js
+++ b/packages/dai-plugin-governance/src/GovQueryApiService.js
@@ -141,4 +141,19 @@ export default class QueryApi extends PublicService {
       return o;
     });
   }
+
+  async getEsmJoins() {
+    const query = `{allEsmJoins {
+      nodes {
+        txFrom
+        txHash
+        joinAmount
+        blockTimestamp
+      }
+  }
+  }`;
+    const response = await this.getQueryResponse(this.serverUrl, query);
+    const joins = response.allEsmJoins.nodes;
+    return joins;
+  }
 }

--- a/packages/dai-plugin-governance/src/utils/helpers.js
+++ b/packages/dai-plugin-governance/src/utils/helpers.js
@@ -1,7 +1,6 @@
 import { createGetCurrency } from '@makerdao/currency';
 import {
   MKR,
-  LOCAL_URL,
   STAGING_MAINNET_URL,
   KOVAN_URL,
   MAINNET_URL
@@ -32,7 +31,7 @@ export const netIdtoSpockUrl = id => {
     case 42:
       return KOVAN_URL;
     default:
-      return LOCAL_URL;
+      return STAGING_MAINNET_URL;
   }
 };
 
@@ -43,7 +42,7 @@ export const netIdtoSpockUrlStaging = id => {
     case 42:
       return KOVAN_URL;
     default:
-      return LOCAL_URL;
+      return STAGING_MAINNET_URL;
   }
 };
 

--- a/packages/dai-plugin-governance/test/EsmService.test.js
+++ b/packages/dai-plugin-governance/test/EsmService.test.js
@@ -7,6 +7,8 @@ import {
 } from './helpers';
 import EsmService from '../src/EsmService';
 
+import { dummyEsmData, parsedDummyEsmData } from './fixtures';
+
 let maker, esmService;
 beforeAll(async () => {
   maker = await setupTestMakerInstance();
@@ -103,4 +105,12 @@ xtest('can trigger emergency shutdown', async () => {
   console.log(fireable);
   const active = await esmService.emergencyShutdownActive();
   expect(active).toBe(true);
+});
+
+test('get staking history', async () => {
+  const mockFn = jest.fn(async () => dummyEsmData);
+  maker.service('govQueryApi').getEsmJoins = mockFn;
+  const stakes = await esmService.getStakingHistory();
+  expect(mockFn).toBeCalled();
+  expect(stakes).toEqual(parsedDummyEsmData);
 });

--- a/packages/dai-plugin-governance/test/fixtures.js
+++ b/packages/dai-plugin-governance/test/fixtures.js
@@ -1,3 +1,5 @@
+import { MKR } from '../src/utils/constants';
+
 export const dummyMkrSupportData = [
   {
     optionId: 1,
@@ -44,3 +46,37 @@ export const dummyNumUnique = 225;
 export const dummyWeight = 5.5;
 
 export const dummyOption = 1;
+
+export const dummyEsmData = [
+  {
+    txFrom: '0x16fb96a5fa0427af0c8f7cf1eb4870231c8154b6',
+    txHash:
+      '0x992dc7815d91eedb691ff4a7192bafc79f624534655ee0663c555252f9e48e22',
+    joinAmount: '0.100000000000000000',
+    blockTimestamp: '2019-11-13T15:03:28+00:00'
+  },
+  {
+    txFrom: '0x14341f81df14ca86e1420ec9e6abd343fb1c5bfc',
+    txHash:
+      '0x6cead96909408284c77dca7a96c18df75c3f0c0eb6e972c2c0fb84f569648bfe',
+    joinAmount: '0.010000000000000000',
+    blockTimestamp: '2020-01-10T00:16:16+00:00'
+  }
+];
+
+export const parsedDummyEsmData = [
+  {
+    senderAddress: '0x14341f81df14ca86e1420ec9e6abd343fb1c5bfc',
+    transactionHash:
+      '0x6cead96909408284c77dca7a96c18df75c3f0c0eb6e972c2c0fb84f569648bfe',
+    amount: MKR(0.01),
+    time: new Date('2020-01-10T00:16:16+00:00')
+  },
+  {
+    senderAddress: '0x16fb96a5fa0427af0c8f7cf1eb4870231c8154b6',
+    transactionHash:
+      '0x992dc7815d91eedb691ff4a7192bafc79f624534655ee0663c555252f9e48e22',
+    amount: MKR(0.1),
+    time: new Date('2019-11-13T15:03:28+00:00')
+  }
+];

--- a/packages/dai-plugin-governance/test/integration/govQueryApiService.test.js
+++ b/packages/dai-plugin-governance/test/integration/govQueryApiService.test.js
@@ -5,6 +5,7 @@ let service;
 beforeAll(async () => {
   const maker = await setupTestMakerInstance();
   service = maker.service('govQueryApi');
+  jest.setTimeout(10000);
 });
 
 test('get all active polls', async () => {
@@ -35,4 +36,9 @@ test('get mkr weight by option', async () => {
 test('get block number', async () => {
   const num = await service.getBlockNumber(1511634513);
   console.log('num', num);
+});
+
+test('get esm joins', async () => {
+  const joins = await service.getEsmJoins();
+  console.log('joins', joins);
 });


### PR DESCRIPTION
Adds a getStakingHistory() function to Esm Service.  I [updated](https://github.com/makerdao/gov-polling-db/blob/staging/migrations/017-esm-query.sql
 the kovan and mainnet staging gov-polling-db deployments to include the allEsmJoins query used here.  Planning on updating the production mainnet one after some more testing.