### PR TITLE
Gov 308 polling time arg

### DIFF
--- a/packages/dai-plugin-governance/package.json
+++ b/packages/dai-plugin-governance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@makerdao/dai-plugin-governance",
   "description": "A dai.js plugin for adding MKR governance support to dapps.",
-  "version": "0.9.1-rc.1",
+  "version": "0.9.1-rc.2",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/dai-plugin-governance/src/GovPollingService.js
+++ b/packages/dai-plugin-governance/src/GovPollingService.js
@@ -120,37 +120,4 @@ export default class GovPollingService extends PrivateService {
     }
     return max ? max.optionId : 0;
   }
-
-  // async getVoteHistory(pollId, numPlots) {
-  //   const { startDate, endDate } = await this._getPoll(pollId);
-  //   const startUnix = Math.floor(startDate / 1000);
-  //   const endUnix = Math.floor(endDate / 1000);
-  //   const voteHistory = [];
-  //   const interval = Math.round((endUnix - startUnix) / numPlots);
-  //   if (interval === 0) {
-  //     const mkrSupport = await this.get('govQueryApi').getMkrSupport(
-  //       pollId,
-  //       endBlock
-  //     );
-  //     voteHistory.push([
-  //       {
-  //         time: mkrSupport[0].blockTimestamp,
-  //         options: mkrSupport
-  //       }
-  //     ]);
-  //   } else {
-  //     for (let i = endBlock; i >= startBlock; i -= interval) {
-  //       const mkrSupport = await this.get('govQueryApi').getMkrSupport(
-  //         pollId,
-  //         i
-  //       );
-  //       const time = mkrSupport.length > 0 ? mkrSupport[0].blockTimestamp : 0;
-  //       voteHistory.push({
-  //         time,
-  //         options: mkrSupport
-  //       });
-  //     }
-  //   }
-  //   return voteHistory;
-  // }
 }

--- a/packages/dai-plugin-governance/src/GovPollingService.js
+++ b/packages/dai-plugin-governance/src/GovPollingService.js
@@ -85,10 +85,9 @@ export default class GovPollingService extends PrivateService {
   async getMkrAmtVoted(pollId) {
     const { endDate } = await this._getPoll(pollId);
     const endUnix = Math.floor(endDate / 1000);
-    const endBlock = await this.get('govQueryApi').getBlockNumber(endUnix);
     const weights = await this.get('govQueryApi').getMkrSupport(
       pollId,
-      endBlock
+      endUnix
     );
     return MKR(weights.reduce((acc, cur) => acc + cur.mkrSupport, 0));
   }
@@ -109,10 +108,9 @@ export default class GovPollingService extends PrivateService {
   async getWinningProposal(pollId) {
     const { endDate } = await this._getPoll(pollId);
     const endUnix = Math.floor(endDate / 1000);
-    const endBlock = await this.get('govQueryApi').getBlockNumber(endUnix);
     const currentVotes = await this.get('govQueryApi').getMkrSupport(
       pollId,
-      endBlock
+      endUnix
     );
     let max = currentVotes[0];
     for (let i = 1; i < currentVotes.length; i++) {
@@ -123,41 +121,36 @@ export default class GovPollingService extends PrivateService {
     return max ? max.optionId : 0;
   }
 
-  async getVoteHistory(pollId, numPlots) {
-    const { startDate, endDate } = await this._getPoll(pollId);
-    const startUnix = Math.floor(startDate / 1000);
-    const endUnix = Math.floor(endDate / 1000);
-    const [startBlock, endBlock] = await Promise.all([
-      this.get('govQueryApi').getBlockNumber(startUnix),
-      this.get('govQueryApi').getBlockNumber(endUnix) //should return current block number if endDate hasn't happened yet
-    ]);
-
-    const voteHistory = [];
-    const interval = Math.round((endBlock - startBlock) / numPlots);
-    if (interval === 0) {
-      const mkrSupport = await this.get('govQueryApi').getMkrSupport(
-        pollId,
-        endBlock
-      );
-      voteHistory.push([
-        {
-          time: mkrSupport[0].blockTimestamp,
-          options: mkrSupport
-        }
-      ]);
-    } else {
-      for (let i = endBlock; i >= startBlock; i -= interval) {
-        const mkrSupport = await this.get('govQueryApi').getMkrSupport(
-          pollId,
-          i
-        );
-        const time = mkrSupport.length > 0 ? mkrSupport[0].blockTimestamp : 0;
-        voteHistory.push({
-          time,
-          options: mkrSupport
-        });
-      }
-    }
-    return voteHistory;
-  }
+  // async getVoteHistory(pollId, numPlots) {
+  //   const { startDate, endDate } = await this._getPoll(pollId);
+  //   const startUnix = Math.floor(startDate / 1000);
+  //   const endUnix = Math.floor(endDate / 1000);
+  //   const voteHistory = [];
+  //   const interval = Math.round((endUnix - startUnix) / numPlots);
+  //   if (interval === 0) {
+  //     const mkrSupport = await this.get('govQueryApi').getMkrSupport(
+  //       pollId,
+  //       endBlock
+  //     );
+  //     voteHistory.push([
+  //       {
+  //         time: mkrSupport[0].blockTimestamp,
+  //         options: mkrSupport
+  //       }
+  //     ]);
+  //   } else {
+  //     for (let i = endBlock; i >= startBlock; i -= interval) {
+  //       const mkrSupport = await this.get('govQueryApi').getMkrSupport(
+  //         pollId,
+  //         i
+  //       );
+  //       const time = mkrSupport.length > 0 ? mkrSupport[0].blockTimestamp : 0;
+  //       voteHistory.push({
+  //         time,
+  //         options: mkrSupport
+  //       });
+  //     }
+  //   }
+  //   return voteHistory;
+  // }
 }

--- a/packages/dai-plugin-governance/src/GovQueryApiService.js
+++ b/packages/dai-plugin-governance/src/GovQueryApiService.js
@@ -86,8 +86,10 @@ export default class QueryApi extends PublicService {
     }
     }`;
     const response = await this.getQueryResponse(this.serverUrl, query);
-    if (!response.totalMkrWeightProxyAndNoProxyByAddress.nodes[0]) return 0;
-    return response.totalMkrWeightProxyAndNoProxyByAddress.nodes[0].weight;
+    if (!response.totalMkrWeightProxyAndNoProxyByAddressAtTime.nodes[0])
+      return 0;
+    return response.totalMkrWeightProxyAndNoProxyByAddressAtTime.nodes[0]
+      .weight;
   }
 
   async getOptionVotingFor(address, pollId) {
@@ -114,7 +116,7 @@ export default class QueryApi extends PublicService {
   }
 
   async getMkrSupport(pollId, unixTime) {
-    const query = `{voteOptionMkrWeightsAtTime(argPollId: ${pollId}, argBlockNumber: ${unixTime}){
+    const query = `{voteOptionMkrWeightsAtTime(argPollId: ${pollId}, argUnix: ${unixTime}){
     nodes{
       optionId
       mkrSupport
@@ -122,7 +124,7 @@ export default class QueryApi extends PublicService {
   }
   }`;
     const response = await this.getQueryResponseMemoized(this.serverUrl, query);
-    let weights = response.voteOptionMkrWeights.nodes;
+    let weights = response.voteOptionMkrWeightsAtTime.nodes;
     // We don't want to calculate votes for 0:abstain
     weights = weights.filter(o => o.optionId !== 0);
     const totalWeight = weights.reduce((acc, cur) => {
@@ -137,7 +139,6 @@ export default class QueryApi extends PublicService {
         : parseFloat(o.mkrSupport);
       o.mkrSupport = mkrSupport;
       o.percentage = (100 * mkrSupport) / totalWeight;
-      o.blockTimestamp = new Date(o.blockTimestamp);
       return o;
     });
   }

--- a/packages/dai-plugin-governance/src/GovQueryApiService.js
+++ b/packages/dai-plugin-governance/src/GovQueryApiService.js
@@ -77,8 +77,8 @@ export default class QueryApi extends PublicService {
     return parseInt(response.uniqueVoters.nodes[0]);
   }
 
-  async getMkrWeight(address, blockNumber) {
-    const query = `{totalMkrWeightProxyAndNoProxyByAddress(argAddress: "${address}", argBlockNumber: ${blockNumber}){
+  async getMkrWeight(address, unixTime) {
+    const query = `{totalMkrWeightProxyAndNoProxyByAddressAtTime(argAddress: "${address}", argUnix: ${unixTime}){
       nodes {
         address
         weight
@@ -113,8 +113,8 @@ export default class QueryApi extends PublicService {
     return response.timeToBlockNumber.nodes[0];
   }
 
-  async getMkrSupport(pollId, blockNumber) {
-    const query = `{voteOptionMkrWeights(argPollId: ${pollId}, argBlockNumber: ${blockNumber}){
+  async getMkrSupport(pollId, unixTime) {
+    const query = `{voteOptionMkrWeightsAtTime(argPollId: ${pollId}, argBlockNumber: ${unixTime}){
     nodes{
       optionId
       mkrSupport

--- a/packages/dai-plugin-governance/test/GovPollingService.test.js
+++ b/packages/dai-plugin-governance/test/GovPollingService.test.js
@@ -7,7 +7,6 @@ import GovPollingService from '../src/GovPollingService';
 import {
   dummyMkrSupportData,
   dummyAllPollsData,
-  dummyBlockNumber,
   dummyOption,
   dummyWeight,
   dummyNumUnique
@@ -134,21 +133,21 @@ test('getWinningProposal', async () => {
   expect(option).toBe(2);
 });
 
-test('getVoteHistory', async () => {
-  // clear polls cache
-  govPollingService.refresh();
-  const mockFn1 = jest.fn(async () => dummyAllPollsData);
-  govQueryApiService.getAllWhitelistedPolls = mockFn1;
-  const mockFn2 = jest.fn(async () => dummyMkrSupportData);
-  govQueryApiService.getMkrSupport = mockFn2;
-  const mockFn3 = jest.fn(async t => dummyBlockNumber(t));
-  govQueryApiService.getBlockNumber = mockFn3;
-  const history = await govPollingService.getVoteHistory(1, 3);
-  expect(mockFn1).toBeCalled();
-  expect(mockFn2).toBeCalled();
-  expect(mockFn3).toBeCalled();
-  expect(history[0].options).toBe(dummyMkrSupportData);
-});
+// test('getVoteHistory', async () => {
+//   // clear polls cache
+//   govPollingService.refresh();
+//   const mockFn1 = jest.fn(async () => dummyAllPollsData);
+//   govQueryApiService.getAllWhitelistedPolls = mockFn1;
+//   const mockFn2 = jest.fn(async () => dummyMkrSupportData);
+//   govQueryApiService.getMkrSupport = mockFn2;
+//   const mockFn3 = jest.fn(async t => dummyBlockNumber(t));
+//   govQueryApiService.getBlockNumber = mockFn3;
+//   const history = await govPollingService.getVoteHistory(1, 3);
+//   expect(mockFn1).toBeCalled();
+//   expect(mockFn2).toBeCalled();
+//   expect(mockFn3).toBeCalled();
+//   expect(history[0].options).toBe(dummyMkrSupportData);
+// });
 
 test('getPercentageMkrVoted', async () => {
   const mockFn = jest.fn(async () => dummyMkrSupportData);

--- a/packages/dai-plugin-governance/test/GovPollingService.test.js
+++ b/packages/dai-plugin-governance/test/GovPollingService.test.js
@@ -133,22 +133,6 @@ test('getWinningProposal', async () => {
   expect(option).toBe(2);
 });
 
-// test('getVoteHistory', async () => {
-//   // clear polls cache
-//   govPollingService.refresh();
-//   const mockFn1 = jest.fn(async () => dummyAllPollsData);
-//   govQueryApiService.getAllWhitelistedPolls = mockFn1;
-//   const mockFn2 = jest.fn(async () => dummyMkrSupportData);
-//   govQueryApiService.getMkrSupport = mockFn2;
-//   const mockFn3 = jest.fn(async t => dummyBlockNumber(t));
-//   govQueryApiService.getBlockNumber = mockFn3;
-//   const history = await govPollingService.getVoteHistory(1, 3);
-//   expect(mockFn1).toBeCalled();
-//   expect(mockFn2).toBeCalled();
-//   expect(mockFn3).toBeCalled();
-//   expect(history[0].options).toBe(dummyMkrSupportData);
-// });
-
 test('getPercentageMkrVoted', async () => {
   const mockFn = jest.fn(async () => dummyMkrSupportData);
   govQueryApiService.getMkrSupport = mockFn;

--- a/packages/dai-plugin-governance/test/integration/govQueryApiService.test.js
+++ b/packages/dai-plugin-governance/test/integration/govQueryApiService.test.js
@@ -3,7 +3,7 @@ import { setupTestMakerInstance } from '../helpers';
 let service;
 
 beforeAll(async () => {
-  const maker = await setupTestMakerInstance();
+  const maker = await setupTestMakerInstance('kovan');
   service = maker.service('govQueryApi');
   jest.setTimeout(10000);
 });


### PR DESCRIPTION
pass in timestamps to gov-polling-db instead of block numbers.  Already updated the production gov-polling-db to include the new queries: https://github.com/makerdao/gov-polling-db/commit/d1628dbb0e9b069d1c2ae4e396bef0ff362e7889