### PR TITLE
Export mcd plugin as both `default` and `McdPlugin`

### DIFF
--- a/packages/dai-plugin-mcd/README.md
+++ b/packages/dai-plugin-mcd/README.md
@@ -6,7 +6,7 @@ multi-collateral dai contracts
 ### Example usage
 
 ```js
-import McdPlugin, { ETH, REP, MDAI } from '@makerdao/dai-plugin-mcd';
+import { McdPlugin, ETH, REP, MDAI } from '@makerdao/dai-plugin-mcd';
 import Maker from '@makerdao/dai';
 import { createCurrency } from '@makerdao/currency';
 import { tokenAddress, tokenAbi } from 'someOtherTokenData';

--- a/packages/dai-plugin-mcd/src/index.js
+++ b/packages/dai-plugin-mcd/src/index.js
@@ -99,7 +99,7 @@ export const defaultTokens = [
   ])
 ];
 
-export default {
+export const McdPlugin = {
   addConfig: (
     _,
     { cdpTypes = defaultCdpTypes, addressOverrides, prefetch = true } = {}
@@ -153,3 +153,5 @@ export default {
     };
   }
 };
+
+export default McdPlugin;

--- a/packages/dai-plugin-mcd/test/helpers.js
+++ b/packages/dai-plugin-mcd/test/helpers.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { createCurrencyRatio } from '@makerdao/currency';
 import Maker from '../../dai/src';
-import McdPlugin, { ETH, USD, GNT } from '../src';
+import { McdPlugin, ETH, USD, GNT } from '../src';
 import { ServiceRoles } from '../src/constants';
 import { stringToBytes } from '../src/utils';
 import ethAbi from 'web3-eth-abi';

--- a/packages/dai-plugin-mcd/test/index.spec.js
+++ b/packages/dai-plugin-mcd/test/index.spec.js
@@ -1,4 +1,4 @@
-import McdPlugin, { BAT } from '../src';
+import { McdPlugin, BAT } from '../src';
 import { mcdMaker } from './helpers';
 import addresses from '../contracts/addresses/testnet.json';
 
@@ -59,4 +59,9 @@ test('BAT token basic functionality', async () => {
   const token = maker.getToken('BAT');
   expect(token.address()).toEqual(addresses.BAT);
   expect(await token.balance()).toEqual(BAT(1000));
+});
+
+test('McdPlugin has a named and a default export', async () => {
+  expect(require('../src').default).toEqual(McdPlugin);
+  expect(require('../src').McdPlugin).toEqual(McdPlugin);
 });


### PR DESCRIPTION
Approach based on discussion in the comments of this [ticket](https://makerdao.atlassian.net/browse/SDK-773). Draft documentation updates on gitbook can be found [here](https://app.gitbook.com/@makerdao-1/s/mcd-docs-1/~/drafts/-M11TvYGmf-2kUvZyL2S/building-with-maker/daijs/getting-started/@activity.)