### PR TITLE
Ignore abstain

### DIFF
--- a/packages/dai-plugin-governance/src/GovPollingService.ts
+++ b/packages/dai-plugin-governance/src/GovPollingService.ts
@@ -348,7 +348,7 @@ export default class GovPollingService extends PrivateService {
 
     // The winner is the first option, unless the first option is "0" which is abstain
     // in that case we pick the next option
-    const winner = (sorted[0] && sorted[0].optionId !== 0
+    const winner = (sorted[0] && sorted[0].optionId !== '0'
       ? sorted[0].optionId
       : sorted[1].optionId
     ).toString();

--- a/packages/dai-plugin-governance/src/GovPollingService.ts
+++ b/packages/dai-plugin-governance/src/GovPollingService.ts
@@ -346,7 +346,10 @@ export default class GovPollingService extends PrivateService {
       prev.mkrSupport.gt(next.mkrSupport) ? -1 : 1
     );
 
-    const winner = (sorted[0] ? sorted[0].optionId : 0).toString();
+
+    // The winner is the first option, unless the first option is "0" which is abstain
+    // in that case we pick the next option
+    const winner = (sorted[0] && sorted[0].optionId !== 0 ? sorted[0].optionId : sorted[1].optionId).toString();
 
     const totalMkrParticipation = summedSupport.reduce(
       (acc, cur) => new BigNumber(cur.mkrSupport || 0).plus(acc),

--- a/packages/dai-plugin-governance/src/GovPollingService.ts
+++ b/packages/dai-plugin-governance/src/GovPollingService.ts
@@ -346,10 +346,12 @@ export default class GovPollingService extends PrivateService {
       prev.mkrSupport.gt(next.mkrSupport) ? -1 : 1
     );
 
-
     // The winner is the first option, unless the first option is "0" which is abstain
     // in that case we pick the next option
-    const winner = (sorted[0] && sorted[0].optionId !== 0 ? sorted[0].optionId : sorted[1].optionId).toString();
+    const winner = (sorted[0] && sorted[0].optionId !== 0
+      ? sorted[0].optionId
+      : sorted[1].optionId
+    ).toString();
 
     const totalMkrParticipation = summedSupport.reduce(
       (acc, cur) => new BigNumber(cur.mkrSupport || 0).plus(acc),

--- a/packages/dai-plugin-governance/test/GovPollingService.test.js
+++ b/packages/dai-plugin-governance/test/GovPollingService.test.js
@@ -28,7 +28,8 @@ import {
   dummyBallotStopWhenOneRemains,
   dummyBallotStopWhenOneRemainsExpect,
   dummyMkrGetMkrSupportRCForPluralityData,
-  dummyMkrGetMkrSupportRCForPluralityDataAdjusted
+  dummyMkrGetMkrSupportRCForPluralityDataAdjusted,
+  dummyMkrGetMkrSupportRCForPluralityDataAbstain
 } from './fixtures';
 import { MKR } from '../src/utils/constants';
 
@@ -383,6 +384,38 @@ test('plurality tally with adjusted votes', async () => {
       '2': {
         mkrSupport: '1232',
         winner: true
+      }
+    }
+  };
+
+  expect(JSON.parse(JSON.stringify(tally))).toEqual(expectedResult);
+});
+
+test('plurality tally with abstain majority ', async () => {
+  govQueryApiService.getMkrSupportRankedChoice = jest.fn(
+    () => dummyMkrGetMkrSupportRCForPluralityDataAbstain
+  );
+  govPollingService._getPoll = jest.fn(() => ({
+    endDate: 123
+  }));
+  const tally = await govPollingService.getTallyPlurality();
+
+  const expectedResult = {
+    winner: '1',
+    totalMkrParticipation: '2041',
+    numVoters: 7,
+    options: {
+      '0': {
+        mkrSupport: '1309',
+        winner: false
+      },
+      '1': {
+        mkrSupport: '700',
+        winner: true
+      },
+      '2': {
+        mkrSupport: '32',
+        winner: false
       }
     }
   };

--- a/packages/dai-plugin-governance/test/fixtures.js
+++ b/packages/dai-plugin-governance/test/fixtures.js
@@ -69,6 +69,38 @@ export const dummyMkrGetMkrSupportRCForPluralityDataAdjusted = [
   }
 ];
 
+
+export const dummyMkrGetMkrSupportRCForPluralityDataAbstain = [
+  {
+    optionIdRaw: '1',
+    mkrSupport: '40'
+  },
+  {
+    optionIdRaw: '1',
+    mkrSupport: '60'
+  },
+  {
+    optionIdRaw: '0',
+    mkrSupport: '77'
+  },
+  {
+    optionIdRaw: '0',
+    mkrSupport: '32'
+  },
+  {
+    optionIdRaw: '1',
+    mkrSupport: '600'
+  },
+  {
+    optionIdRaw: '2',
+    mkrSupport: '32'
+  },
+  {
+    optionIdRaw: '0',
+    mkrSupport: '1200'
+  }
+];
+
 export const dummyAllPollsData = [
   {
     creator: '0xeda95d1bdb60f901986f43459151b6d1c734b8a2',

--- a/packages/dai-plugin-governance/test/fixtures.js
+++ b/packages/dai-plugin-governance/test/fixtures.js
@@ -69,7 +69,6 @@ export const dummyMkrGetMkrSupportRCForPluralityDataAdjusted = [
   }
 ];
 
-
 export const dummyMkrGetMkrSupportRCForPluralityDataAbstain = [
   {
     optionIdRaw: '1',


### PR DESCRIPTION
Ignores abstain as a winning option in plurality votes, takes the next option as the correct one https://app.shortcut.com/dux-makerdao/story/722/ignore-abstain-as-winning-poll-vote-option