### PR TITLE
Update gas price fields for 1559

### DIFF
--- a/packages/dai/src/eth/TransactionManager.js
+++ b/packages/dai/src/eth/TransactionManager.js
@@ -184,7 +184,11 @@ export default class TransactionManager extends PublicService {
 
     if (!this.get('gas').disablePrice) {
       let txSpeed = options.transactionSpeed;
-      options.gasPrice = await this.get('gas').getGasPrice(txSpeed);
+      options.maxFeePerGas = await this.get('gas').getGasPrice(txSpeed);
+      options.maxPriorityFeePerGas = this.get('web3')._web3.utils.toWei(
+        (2.5).toString(),
+        'gwei'
+      );
     }
 
     return {

--- a/packages/dai/test/eth/TransactionManager.spec.js
+++ b/packages/dai/test/eth/TransactionManager.spec.js
@@ -102,7 +102,8 @@ test('wrapped contract call adds nonce, web3 settings', async () => {
     {
       gasLimit: 1234567,
       nonce: expect.any(Number),
-      gasPrice: gasPrice
+      maxFeePerGas: gasPrice,
+      maxPriorityFeePerGas: '2500000000'
     }
   );
 }, 30000);
@@ -321,7 +322,12 @@ describe('transaction options', () => {
       'open',
       []
     );
-    expect(Object.keys(options)).toEqual(['gasLimit', 'gasPrice', 'nonce']);
+    expect(Object.keys(options)).toEqual([
+      'gasLimit',
+      'maxFeePerGas',
+      'maxPriorityFeePerGas',
+      'nonce'
+    ]);
 
     txManager.get('gas').disablePrice = true;
     options = await txManager._buildTransactionOptions(
@@ -343,7 +349,8 @@ describe('transaction options', () => {
     expect(Object.keys(options)).toEqual([
       'value',
       'gasLimit',
-      'gasPrice',
+      'maxFeePerGas',
+      'maxPriorityFeePerGas',
       'nonce'
     ]);
   }, 30000);


### PR DESCRIPTION
Instead of setting `gasPrice`, we set `maxFeePerGas` and `maxPriorityFeePerGas`. `maxPriorityFeePerGas` is hardcoded to 2.5 gwei.

More info for the gas fields expected in web3 `sendTransaction`: https://web3js.readthedocs.io/en/v1.5.2/web3-eth.html#sendtransaction

More info for changes from infura: https://blog.infura.io/london-fork/